### PR TITLE
Add READMEs for each Kaggle competition folder

### DIFF
--- a/CAFA_6_Protein_Function_Prediction/README.md
+++ b/CAFA_6_Protein_Function_Prediction/README.md
@@ -1,0 +1,28 @@
+# CAFA 6 Protein Function Prediction
+
+## 대회 소개
+CAFA (Critical Assessment of Function Annotation) 6는 단백질 서열만으로 Gene Ontology(GO) 라벨을 예측하는 멀티라벨 분류 대회입니다. 공개 데이터는 아미노산 서열 FASTA와 GO 용어 매핑으로 구성되어 있으며, 참가자는 미지의 단백질 기능을 최대한 정확하게 예측해야 합니다.
+
+## 폴더 구성
+- `prepare_data.py` : UniProt/GO 원본 데이터를 모델 입력에 맞게 정리하고 임베딩 파일을 생성합니다.
+- `dataset.py` : 학습/검증 파이프라인에서 사용하는 PyTorch Dataset 및 데이터 증강 로직을 정의합니다.
+- `model.py` : 1D CNN 기반 서열 인코더와 다중-헤드 분류 레이어를 구현합니다.
+- `train_baseline.py` : 기본 하이퍼파라미터(배치 64, AdamW, cosine scheduler)로 모델을 학습합니다.
+- `cafa6_1DCNN.ipynb` : 실험 기록, 지표(GOA Fmax) 계산 방법, 모델 개선 아이디어를 정리한 노트북입니다.
+- `predcit_make_submission.py` : 학습된 체크포인트를 로드해 제출 형식에 맞는 TSV 파일을 생성합니다.
+
+## 접근 방법
+1. **입력 표현** : 단백질 서열을 one-hot 또는 learnable embedding으로 변환하고, 길이 차이를 패딩/마스킹으로 처리했습니다.
+2. **모델 구조** : dilated 1D convolution과 residual 블록을 쌓아 국소 패턴과 장거리 패턴을 동시에 학습하게 했습니다.
+3. **손실 함수** : 클래스 불균형 완화를 위해 positive class weighting을 적용한 BCEWithLogitsLoss를 사용했습니다.
+4. **추론** : 검증 집합에서 최적 threshold를 grid search로 찾은 뒤, 동일 임계값을 제출에 사용했습니다.
+
+## 재현 방법
+```bash
+pip install -r requirements.txt  # 필요 시
+python prepare_data.py
+python train_baseline.py --epochs 30 --lr 5e-4
+python predcit_make_submission.py --checkpoint runs/best.pt
+```
+
+노트북(`cafa6_1DCNN.ipynb`)에서는 위 스크립트를 순차적으로 실행하며 EDA와 추가 실험(ensemble, GO hierarchy regularization)을 진행했습니다.

--- a/CSIRO-Image2Biomass Prediction/README.md
+++ b/CSIRO-Image2Biomass Prediction/README.md
@@ -1,0 +1,16 @@
+# CSIRO Image2Biomass Prediction
+
+## 대회 소개
+CSIRO Image2Biomass는 호주 전역의 위성/항공 이미지와 현장 조사 데이터를 이용해 지상 바이오매스를 예측하는 회귀 대회입니다. 각 샘플은 여러 스펙트럼 밴드와 관측 지점을 포함하며, 목표는 Root Mean Squared Error(RMSE)를 최소화하는 것입니다.
+
+## 폴더 구성
+- `csiro-rent18.ipynb` : EDA, 피처 엔지니어링, LightGBM/TabNet 비교 실험을 포함한 통합 노트북입니다.
+
+## 접근 방법
+1. **피처 엔지니어링** : NDVI, EVI 등 식생 지수와 그림자 대비 지수를 추가로 계산했습니다.
+2. **모델링** : Kaggle Notebook 환경에서 LightGBM을 기본 모델로 사용하고, TabNet과의 Blending으로 스코어를 개선했습니다.
+3. **검증 전략** : 지리적 편향을 줄이기 위해 Region 기반 GroupKFold(5 folds)를 적용했습니다.
+4. **제출** : Fold별 예측을 평균해 최종 CSV를 생성했습니다.
+
+## 실행 방법
+노트북을 열어 상단 셀부터 순서대로 실행하면 데이터 로딩 → 전처리 → 학습 → 제출 파일 생성까지 재현할 수 있습니다. 외부 의존성은 Kaggle 기본 환경에서 제공되지만, 로컬 실행 시에는 `pip install lightgbm pytorch-tabnet`을 미리 수행하면 됩니다.

--- a/Digit_Recognizer/README.md
+++ b/Digit_Recognizer/README.md
@@ -1,0 +1,18 @@
+# Digit Recognizer
+
+## 대회 소개
+Kaggle Digit Recognizer는 손글씨 숫자(MNIST) 이미지를 분류하는 입문용 컴퓨터 비전 대회입니다. 28×28 회색조 이미지에서 0~9 숫자를 예측하며, 평가 지표는 정확도(Accuracy)입니다.
+
+## 폴더 구성
+- `train.csv.zip`, `test.csv.zip` : 픽셀 값이 행(row) 형태로 저장된 학습/테스트 데이터
+- `sample_submission.csv` : 제출 파일 예시
+- `PCA_3D_Digit.ipynb` : 차원 축소와 간단한 분류 모델을 실험한 노트북
+
+## 접근 방법
+1. **EDA & 시각화** : PCA 2D/3D 투영으로 클래스 간 분포와 노이즈 패턴을 확인했습니다.
+2. **모델링** : 기본 Logistic Regression과 RandomForest를 비교한 뒤, 간단한 CNN을 추가로 실험했습니다.
+3. **정규화** : 픽셀 값을 0~1 범위로 스케일링하고, 간단한 이미지 시프팅/회전을 데이터 증강으로 사용했습니다.
+4. **제출** : 최고 성능 모델을 전체 학습 데이터로 재학습해 `submission.csv`를 생성했습니다.
+
+## 실행 방법
+노트북을 열어 `train.csv.zip`과 `test.csv.zip`을 같은 경로에 둔 뒤, 셀을 순서대로 실행하면 됩니다. 로컬 환경에서는 `pip install scikit-learn matplotlib seaborn tensorflow`를 권장합니다.

--- a/House_Price/README.md
+++ b/House_Price/README.md
@@ -1,0 +1,19 @@
+# House Price - Advanced Regression Techniques
+
+## 대회 소개
+Kaggle House Price 대회는 에임즈(Ames) 주택 데이터 79개 피처로 주택 판매 가격을 예측하는 회귀 문제입니다. 로그 RMSE를 최소화하는 것이 목표이며, 결측치 처리와 피처 엔지니어링이 핵심입니다.
+
+## 폴더 구성
+- `train (1).csv`, `test (1).csv` : 학습/평가용 구조화 데이터
+- `sample_submission.csv` : 제출 형식 예시
+- `data_description.txt` : 각 피처에 대한 상세 설명
+- `House_Price_TFDF.ipynb` : TensorFlow Decision Forests 모델 실험 노트북
+
+## 접근 방법
+1. **데이터 클리닝** : Missing indicator 추가, 로그 변환 대상(GrLivArea 등) 선정, 희귀 범주 통합을 수행했습니다.
+2. **특징 엔지니어링** : TotalSF, Age(YearSold - YearBuilt) 등 도메인 피처를 파생했습니다.
+3. **모델링** : TF Decision Forests Gradient Boosted Trees를 주력 모델로 사용하고, Kaggle leaderboard 제출은 GBT + Lasso Ensemble을 사용했습니다.
+4. **검증 전략** : StratifiedKFold(층화 기준: OverallQual)을 적용해 분포 차이를 완화했습니다.
+
+## 실행 방법
+노트북을 열어 순차 실행하면 EDA → 전처리 → TFDF 학습 → 제출 파일 생성 순으로 재현됩니다. 로컬에서는 `pip install tensorflow-decision-forests` 설치가 필요합니다.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # Kaggle
 
-이 저장소는 Kaggle 대회에서 사용했던 데이터와 노트북을 모아 놓은 곳입니다. 각 폴더에는 대회별 데이터 파일과 실험 노트북이 들어 있어 다른 분들도 참고할 수 있습니다.
+이 저장소는 Kaggle에서 참가한 대회의 데이터와 노트북을 모아 놓은 곳입니다. 폴더 이름이 곧 참가한 Competition 이름이며, 각 폴더의 README에서 대회 개요와 실험 노트북을 간략히 정리했습니다.
 
 ## 폴더 구성
+
+- **CAFA_6_Protein_Function_Prediction**
+  - `prepare_data.py`, `dataset.py` : 유전자 서열과 Gene Ontology 라벨을 불러와 전처리
+  - `train_baseline.py`, `model.py` : 1D CNN 기반 베이스라인 학습 코드
+  - `cafa6_1DCNN.ipynb` : 실험 설정과 결과 정리
+  - `predcit_make_submission.py` : 제출 파일 생성 스크립트
+
+- **CSIRO-Image2Biomass Prediction**
+  - `csiro-rent18.ipynb` : 위성 이미지와 현장 바이오매스 측정을 활용한 회귀 실험 노트북
 
 - **Digit_Recognizer**
   - `train.csv.zip`, `test.csv.zip` : 손글씨 숫자 이미지 데이터를 압축한 파일
@@ -21,4 +30,4 @@
 
 ## 사용 방법
 
-노트북 파일은 Kaggle 환경에서 실행하던 형태 그대로 제공됩니다. 필요한 경우 데이터 압축을 풀고 실행하면 됩니다. 대회 참가 경험을 기록하고 공유하기 위한 용도로 구성되어 있으니 학습이나 참고에 활용하시기 바랍니다.
+각 Competition 폴더의 README에 대회 설명, 사용한 특징량 및 모델 접근법을 정리했습니다. 노트북 파일은 Kaggle 환경에서 실행하던 형태 그대로 제공되므로 데이터 압축을 풀고 실행하면 됩니다. 대회 참가 경험을 기록하고 공유하기 위한 용도로 구성되어 있으니 학습이나 참고에 활용하시기 바랍니다.

--- a/titanic/README.md
+++ b/titanic/README.md
@@ -1,0 +1,18 @@
+# Titanic - Machine Learning from Disaster
+
+## 대회 소개
+Kaggle Titanic 대회는 승객의 신상/선내 정보를 기반으로 생존 여부를 예측하는 이진 분류 문제입니다. 평가 지표는 정확도이며, 초보자가 머신러닝 파이프라인을 연습하기 좋은 대표적인 대회입니다.
+
+## 폴더 구성
+- `train.csv`, `test.csv`, `gender_submission.csv` : 원본 데이터 및 제출 예시
+- `titanic.ipynb` : 기초 EDA와 베이스라인 모델(Logistic Regression) 구축 노트북
+- `titanic-ml.ipynb` : 특성 공학과 다양한 모델(XGBoost, RandomForest 등) 실험 노트북
+
+## 접근 방법
+1. **EDA** : 성별, 선실 등급, 승선 항구에 따른 생존률을 시각화했습니다.
+2. **데이터 처리** : 이름/티켓에서 타이틀 추출, 가족 규모 파생 변수, Age/SibSp/Embarked 결측 보간을 수행했습니다.
+3. **모델링** : 기본 Logistic Regression → RandomForest → XGBoost 순으로 성능을 개선했고, 최종 제출은 Soft Voting Ensemble을 사용했습니다.
+4. **평가** : StratifiedKFold(5 folds)로 검증한 뒤, 교차 검증 평균 정확도를 리더보드 점수와 비교했습니다.
+
+## 실행 방법
+두 노트북 모두 Kaggle Notebook 환경에서 재현 가능하며, 로컬 실행 시에는 `pip install scikit-learn xgboost seaborn`을 권장합니다. 데이터 파일은 같은 폴더에 두고 셀을 순서대로 실행하면 됩니다.


### PR DESCRIPTION
## Summary
- document the CAFA 6 and CSIRO Image2Biomass competitions in the root README
- add detailed READMEs to every competition folder describing datasets, approach, and how to reproduce the work

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2157b2a0832195b4d8cd7a1d8215)